### PR TITLE
Add SEQ UDP Events and Breakpoints to Dolphin

### DIFF
--- a/Source/Core/Common/SeqQueueThread.h
+++ b/Source/Core/Common/SeqQueueThread.h
@@ -151,7 +151,7 @@ private:
             lg, [&] { return !m_items.empty() || m_shutdown || m_cancelling.load(); });
       }
 
-      // Count how many chunks we can send, maximum of 100.
+      // Count how many chunks we can send, maximum of 1000.
       // The max datagram size for UDP is 65507 bytes, so we must not pass that.
       size_t chunk_count = 1000;
       if (m_items.size() < chunk_count)

--- a/Source/Core/Common/SeqQueueThread.h
+++ b/Source/Core/Common/SeqQueueThread.h
@@ -162,7 +162,7 @@ private:
       if (chunk_count > 0)
       {
         // Read up to 100 chunks
-        std::vector<std::string> chunks(chunk_count);
+        std::vector<std::vector<char>> chunks(chunk_count);
         for (int i = 0; i < chunk_count; i++)
         {
           T item{std::move(m_items.front())};
@@ -174,15 +174,16 @@ private:
         lg.unlock();
 
         // Create single data stream of the chunk(s)
-        std::string full_str;
+        std::vector<char> full_bytes;
         for (int i = 0; i < chunk_count; i++)
         {
-          full_str += chunks[i];
+          full_bytes.insert(full_bytes.end(), chunks[i].begin(), chunks[i].end());
         }
 
         // Send UDP data of multiple chunks
         sf::UdpSocket m_socket;
-        if (m_socket.send(full_str.data(), full_str.size(), sf::IpAddress("localhost"), 12198) !=
+        if (m_socket.send(full_bytes.data(), full_bytes.size(), sf::IpAddress("localhost"),
+                          12198) !=
             sf::Socket::Status::Done)
         {
           printf("SEQ UDPClient send failed");

--- a/Source/Core/Common/SeqQueueThread.h
+++ b/Source/Core/Common/SeqQueueThread.h
@@ -161,17 +161,24 @@ private:
 
       if (chunk_count > 0)
       {
-        // Create single data stream of up to 100 chunks
-        std::string full_str;
+        // Read up to 100 chunks
+        std::vector<std::string> chunks(chunk_count);
         for (int i = 0; i < chunk_count; i++)
         {
           T item{std::move(m_items.front())};
           m_items.pop();
-          full_str += item;
+          chunks[i] = item;
         }
 
-        // Unlock before we send the packet so that the CPU thread can add more chunks to be processed
+        // Now we can unlock the mutex and let other chunks accumulate again
         lg.unlock();
+
+        // Create single data stream of the chunk(s)
+        std::string full_str;
+        for (int i = 0; i < chunk_count; i++)
+        {
+          full_str += chunks[i];
+        }
 
         // Send UDP data of multiple chunks
         sf::UdpSocket m_socket;

--- a/Source/Core/Common/SeqQueueThread.h
+++ b/Source/Core/Common/SeqQueueThread.h
@@ -1,0 +1,199 @@
+// Copyright 2017 Dolphin Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <functional>
+#include <queue>
+#include <string>
+#include <string_view>
+#include <thread>
+
+#include "Common/Thread.h"
+
+#include <SFML/Network/UdpSocket.hpp>
+
+// A thread that executes the given function for every item placed into its queue.
+
+namespace Common
+{
+template <typename T>
+class SeqQueueThread
+{
+public:
+  SeqQueueThread() = default;
+  SeqQueueThread(const std::string_view name, std::function<void(T)> function)
+  {
+    Reset(name, std::move(function));
+  }
+  ~SeqQueueThread() { Shutdown(); }
+
+  // Shuts the current work thread down (if any) and starts a new thread with the given function
+  // Note: Some consumers of this API push items to the queue before starting the thread.
+  void Reset(const std::string_view name)
+  {
+    Shutdown();
+    std::lock_guard lg(m_lock);
+    m_thread_name = name;
+    m_shutdown = false;
+    m_thread = std::thread(&SeqQueueThread::ThreadLoop, this);
+  }
+
+  // Adds an item to the work queue
+  template <typename... Args>
+  void EmplaceItem(Args&&... args)
+  {
+    std::lock_guard lg(m_lock);
+    if (m_shutdown)
+      return;
+
+    m_items.emplace(std::forward<Args>(args)...);
+    m_idle = false;
+    m_worker_cond_var.notify_one();
+  }
+
+  // Adds an item to the work queue
+  void Push(T&& item)
+  {
+    std::lock_guard lg(m_lock);
+    if (m_shutdown)
+      return;
+
+    m_items.push(std::move(item));
+    m_idle = false;
+    m_worker_cond_var.notify_one();
+  }
+
+  // Adds an item to the work queue
+  void Push(const T& item)
+  {
+    std::lock_guard lg(m_lock);
+    if (m_shutdown)
+      return;
+
+    m_items.push(item);
+    m_idle = false;
+    m_worker_cond_var.notify_one();
+  }
+
+  // Empties the queue
+  // If the worker polls IsCanceling(), it can abort it's work when Cancelling
+  void Cancel()
+  {
+    std::unique_lock lg(m_lock);
+    if (m_shutdown)
+      return;
+
+    m_cancelling = true;
+    m_items = std::queue<T>();
+    m_worker_cond_var.notify_one();
+  }
+
+  // Tells the worker to shut down when it's queue is empty
+  // Blocks until the worker thread exits.
+  // If cancel is true, will Cancel before before telling the worker to exit
+  // Otherwise, all currently queued items will complete before the worker exits
+  void Shutdown(bool cancel = false)
+  {
+    {
+      std::unique_lock lg(m_lock);
+      if (m_shutdown || !m_thread.joinable())
+        return;
+
+      if (cancel)
+      {
+        m_cancelling = true;
+        m_items = std::queue<T>();
+      }
+
+      m_shutdown = true;
+      m_worker_cond_var.notify_one();
+    }
+
+    m_thread.join();
+  }
+
+  // Blocks until all items in the queue have been processed (or cancelled)
+  void WaitForCompletion()
+  {
+    std::unique_lock lg(m_lock);
+    // don't check m_shutdown, because it gets set to request a shutdown, and we want to wait until
+    // after the shutdown completes.
+    // We also check m_cancelling, because we want to ensure the worker acknowledges our cancel.
+    if (m_idle && !m_cancelling.load())
+      return;
+
+    m_wait_cond_var.wait(lg, [&] { return m_idle && !m_cancelling; });
+  }
+
+  // If the worker polls IsCanceling(), it can abort its work when Cancelling
+  bool IsCancelling() const { return m_cancelling.load(); }
+
+private:
+  void ThreadLoop()
+  {
+    Common::SetCurrentThreadName(m_thread_name.c_str());
+
+    while (true)
+    {
+      std::unique_lock lg(m_lock);
+      while (m_items.empty())
+      {
+        m_idle = true;
+        m_cancelling = false;
+        m_wait_cond_var.notify_all();
+        if (m_shutdown)
+          return;
+
+        m_worker_cond_var.wait(
+            lg, [&] { return !m_items.empty() || m_shutdown || m_cancelling.load(); });
+      }
+
+      // Count how many chunks we can send, maximum of 100.
+      // The max datagram size for UDP is 65507 bytes, so we must not pass that.
+      size_t chunk_count = 100;
+      if (m_items.size() < chunk_count)
+      {
+        chunk_count = m_items.size();
+      }
+
+      if (chunk_count > 0)
+      {
+        // Create single data stream of up to 100 chunks
+        std::string full_str;
+        for (int i = 0; i < chunk_count; i++)
+        {
+          T item{std::move(m_items.front())};
+          m_items.pop();
+          full_str += item;
+        }
+
+        // Send UDP data of multiple chunks
+        [full_str=full_str]()
+          {
+            sf::UdpSocket m_socket;
+            if (m_socket.send(full_str.data(), full_str.size(), sf::IpAddress("localhost"), 12198) != sf::Socket::Status::Done)
+            {
+              printf("SEQ UDPClient send failed");
+            }
+        }();
+      }
+
+      lg.unlock();
+    }
+  }
+
+  std::string m_thread_name;
+  std::thread m_thread;
+  std::mutex m_lock;
+  std::queue<T> m_items;
+  std::condition_variable m_wait_cond_var;
+  std::condition_variable m_worker_cond_var;
+  std::atomic<bool> m_cancelling = false;
+  bool m_idle = true;
+  bool m_shutdown = false;
+};
+
+}  // namespace Common

--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -404,7 +404,7 @@ const Info<bool> MAIN_USE_BUILT_IN_TITLE_DATABASE{
 const Info<std::string> MAIN_THEME_NAME{{System::Main, "Interface", "ThemeName"},
                                         DEFAULT_THEME_DIR};
 const Info<bool> MAIN_PAUSE_ON_FOCUS_LOST{{System::Main, "Interface", "PauseOnFocusLost"}, false};
-const Info<bool> MAIN_ENABLE_DEBUGGING{{System::Main, "Interface", "DebugModeEnabled"}, false};
+const Info<bool> MAIN_ENABLE_DEBUGGING{{System::Main, "Interface", "DebugModeEnabled"}, true};
 
 // Main.Analytics
 

--- a/Source/Core/Core/PowerPC/BreakPoints.cpp
+++ b/Source/Core/Core/PowerPC/BreakPoints.cpp
@@ -163,6 +163,7 @@ void BreakPoints::Add(u32 offset, const std::string file, std::optional<Expressi
   bp.log_on_hit = true;
   bp.address = offset;
   bp.condition = std::move(condition);
+  bp.file = file;
 
   if (iter != m_breakpoints.end())  // We found an existing breakpoint
   {

--- a/Source/Core/Core/PowerPC/BreakPoints.h
+++ b/Source/Core/Core/PowerPC/BreakPoints.h
@@ -19,7 +19,7 @@ class System;
 struct TBreakPoint
 {
   u32 address = 0;
-  std::string file = "UNSET";
+  std::string file = "main.dol";
   bool is_enabled = false;
   bool log_on_hit = false;
   bool break_on_hit = false;

--- a/Source/Core/Core/PowerPC/BreakPoints.h
+++ b/Source/Core/Core/PowerPC/BreakPoints.h
@@ -19,6 +19,7 @@ class System;
 struct TBreakPoint
 {
   u32 address = 0;
+  std::string file = "";
   bool is_enabled = false;
   bool log_on_hit = false;
   bool break_on_hit = false;
@@ -74,6 +75,7 @@ public:
 
   // Add BreakPoint. If one already exists on the same address, replace it.
   void Add(u32 address, bool break_on_hit, bool log_on_hit, std::optional<Expression> condition);
+  void Add(u32 address, const std::string file, std::optional<Expression> condition);
   void Add(u32 address);
   void Add(TBreakPoint bp);
   // Add temporary breakpoint (e.g., Step Over, Run to Here)

--- a/Source/Core/Core/PowerPC/BreakPoints.h
+++ b/Source/Core/Core/PowerPC/BreakPoints.h
@@ -19,7 +19,7 @@ class System;
 struct TBreakPoint
 {
   u32 address = 0;
-  std::string file = "";
+  std::string file = "UNSET";
   bool is_enabled = false;
   bool log_on_hit = false;
   bool break_on_hit = false;

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -1031,9 +1031,6 @@ bool Jit64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
     }
     else
     {
-      // TODO: This is problematic because it is currently called at the start of seq_parse/SEQ_Exec.
-      // The JIT will run at the start of the method and this specific line of code will be hit once for each
-      // opcode in the method.
       auto& cpu = m_system.GetCPU();
       auto& power_pc = m_system.GetPowerPC();
       auto& memory = m_system.GetMemory();
@@ -1053,6 +1050,7 @@ bool Jit64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
         case 0x800c8e30:
         case 0x800c8ef8:
         case 0x80106f10:
+          // Enable SEQ breakpoints for known games based on GNT4
           isSeqBreakpoint = true;
           break;
         }
@@ -1065,7 +1063,6 @@ bool Jit64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
 
         MOV(32, PPCSTATE(pc), Imm32(op.address));
         ABI_PushRegistersAndAdjustStack({}, 0);
-        // TODO: We likely want our new logic to occur in the below callback since it will be called for this
         ABI_CallFunctionPP(PowerPC::CheckAndHandleBreakPointsFromJIT, &power_pc, &memory);
         ABI_PopRegistersAndAdjustStack({}, 0);
         MOV(64, R(RSCRATCH), ImmPtr(cpu.GetStatePtr()));

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -1034,27 +1034,7 @@ bool Jit64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
       auto& cpu = m_system.GetCPU();
       auto& power_pc = m_system.GetPowerPC();
       auto& memory = m_system.GetMemory();
-      auto& game_id = SConfig::GetInstance().GetGameID();
-      auto& gnt4 = "G4NJDA";
-      auto& scon4 = "SG4JDA";
-      auto& qole = "G4QJDA";
-      bool isSeqBreakpoint = false;
-      if ((game_id == gnt4) || (game_id == scon4) || (game_id == qole))
-      {
-        switch (op.address)
-        {
-        case 0x800c903c:
-        case 0x800c9094:
-        case 0x800c9138:
-        case 0x800c91a0:
-        case 0x800c8e30:
-        case 0x800c8ef8:
-        case 0x80106f10:
-          // Enable SEQ breakpoints for known games based on GNT4
-          isSeqBreakpoint = true;
-          break;
-        }
-      }
+      bool isSeqBreakpoint = power_pc.IsSeqBreakpoint(op.address);
       if (isSeqBreakpoint || (power_pc.GetBreakPoints().IsAddressBreakPoint(op.address) &&
           !cpu.IsStepping()))
       {

--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.cpp
@@ -129,7 +129,7 @@ void JitBase::RefreshConfig()
     m_low_dcbz_hack = false;
   }
 
-  analyzer.SetDebuggingEnabled(m_enable_debugging);
+  analyzer.SetDebuggingEnabled(true); // always enabled for this Dolphin build
   analyzer.SetBranchFollowingEnabled(m_enable_branch_following);
   analyzer.SetFloatExceptionsEnabled(m_enable_float_exceptions);
   analyzer.SetDivByZeroExceptionsEnabled(m_enable_div_by_zero_exceptions);

--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.h
@@ -148,7 +148,7 @@ protected:
   bool bJITBranchOff = false;
   bool bJITRegisterCacheOff = false;
   bool m_enable_profiling = false;
-  bool m_enable_debugging = false;
+  bool m_enable_debugging = true; // always enabled for this Dolphin build
   bool m_enable_branch_following = false;
   bool m_enable_float_exceptions = false;
   bool m_enable_div_by_zero_exceptions = false;
@@ -187,7 +187,7 @@ public:
   ~JitBase() override;
 
   bool IsProfilingEnabled() const { return m_enable_profiling; }
-  bool IsDebuggingEnabled() const { return m_enable_debugging; }
+  bool IsDebuggingEnabled() const { return true; } // always enabled for this Dolphin build
 
   static const u8* Dispatch(JitBase& jit);
   virtual JitBaseBlockCache* GetBlockCache() = 0;

--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -638,7 +638,7 @@ bool PowerPCManager::CheckBreakPoints()
 {
   const TBreakPoint* bp = m_breakpoints.GetBreakpoint(m_ppc_state.pc);
 
-  if (!bp || !bp->is_enabled || !EvaluateCondition(m_system, bp->condition) || bp->file != "")
+  if (!bp || !bp->is_enabled || !EvaluateCondition(m_system, bp->condition) || bp->file == "main.dol")
     return false;
 
   if (bp->log_on_hit)

--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -738,16 +738,15 @@ void CheckAndHandleBreakPointsFromJIT(PowerPCManager& power_pc, Memory::MemoryMa
 
 void PowerPCManager::SendSeqUDPPacket(PowerPCManager& power_pc, Memory::MemoryManager& memory)
 {
-  PowerPCState ppc_state = power_pc.GetPPCState();
-  const u32 pc = ppc_state.pc;
+  const u32 pc = m_ppc_state.pc;
 
   // The start of the seq file is at*(int*)(seq_p[5] + 0x5c)
-  const u32 seq_p = ppc_state.gpr[3];
+  const u32 seq_p = m_ppc_state.gpr[3];
   const u32 temp_p = memory.Read_U32(seq_p + 0x14);
   const u32 seq_start = memory.Read_U32(temp_p + 0x5c);
 
   // The current program counter of the seq file is in general purpose register 5
-  const u32 seq_pc = ppc_state.gpr[5];
+  const u32 seq_pc = m_ppc_state.gpr[5];
 
   // Calculate the offset in the seq file
   const u32 seq_offset = seq_pc - seq_start;

--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -760,8 +760,6 @@ void PowerPCManager::SendSeqUDPPacket(PowerPCManager& power_pc, Memory::MemoryMa
 
   // Calculate the offset in the seq file
   const u32 seq_offset = seq_pc - seq_start;
-  char offset_str[9];
-  snprintf(offset_str, 9, "%08x", seq_offset);
 
   // Get the file name, which can be found at seq_p[8][5]
   const u32 file_entry = memory.Read_U32(seq_p + 0x20);
@@ -769,16 +767,24 @@ void PowerPCManager::SendSeqUDPPacket(PowerPCManager& power_pc, Memory::MemoryMa
 
   // Get the current opcode being executed
   const u32 opcode = memory.Read_U32(seq_pc);
-  char opcode_str[9];
-  snprintf(opcode_str, 9, "%08x", opcode);
 
-  // Get the program counter
-  char pc_str[9];
-  snprintf(pc_str, 9, "%08x", pc);
-
-  std::string full_str = std::string(offset_str) + " " + opcode_str + " " + pc_str + " " + file_name_str;
+  std::vector<char> bytes;
+  bytes.push_back(static_cast<uint8_t>((seq_offset >> 24) & 0xFF));
+  bytes.push_back(static_cast<uint8_t>((seq_offset >> 16) & 0xFF));
+  bytes.push_back(static_cast<uint8_t>((seq_offset >> 8) & 0xFF));
+  bytes.push_back(static_cast<uint8_t>(seq_offset & 0xFF));
+  bytes.push_back(static_cast<uint8_t>((opcode >> 24) & 0xFF));
+  bytes.push_back(static_cast<uint8_t>((opcode >> 16) & 0xFF));
+  bytes.push_back(static_cast<uint8_t>((opcode >> 8) & 0xFF));
+  bytes.push_back(static_cast<uint8_t>(opcode & 0xFF));
+  bytes.push_back(static_cast<uint8_t>((pc >> 24) & 0xFF));
+  bytes.push_back(static_cast<uint8_t>((pc >> 16) & 0xFF));
+  bytes.push_back(static_cast<uint8_t>((pc >> 8) & 0xFF));
+  bytes.push_back(static_cast<uint8_t>(pc & 0xFF));
+  bytes.insert(bytes.end(), file_name_str.begin(), file_name_str.end());
+  bytes.push_back(0); // null terminator
 
   // Asynchronously send UDP packet
-  m_udp_queue.Push(full_str);
+  m_udp_queue.Push(bytes);
 }
 }  // namespace PowerPC

--- a/Source/Core/Core/PowerPC/PowerPC.cpp
+++ b/Source/Core/Core/PowerPC/PowerPC.cpp
@@ -805,11 +805,17 @@ bool PowerPCManager::CheckSeqExecution(PowerPCManager& power_pc, Memory::MemoryM
   m_udp_queue.Push(bytes);
 
   // Check for SEQ breakpoints
-  if (CheckSeqBreakPoints(file_name_str, seq_offset))
+  if (recent_seq_bp)
+  {
+    // Needed to prevent infinite breaking on the same SEQ breakpoint
+    recent_seq_bp = false;
+  }
+  else if (CheckSeqBreakPoints(file_name_str, seq_offset))
   {
     m_system.GetCPU().Break();
     if (GDBStub::IsActive())
       GDBStub::TakeControl();
+    recent_seq_bp = true;
     return true;
   }
   return false;

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -286,6 +286,8 @@ public:
   void CheckExternalExceptions();
   // Evaluate the breakpoints in order to log. Returns whether it would break.
   bool CheckBreakPoints();
+  // Evaluate the SEQ breakpoints in order to log. Pass in the file and offset we are at. Returns whether it would break.
+  bool CheckSeqBreakPoints(std::string file, u32 offset);
   // Evaluate the breakpoints in order to log and/or break. Returns whether it breaks.
   bool CheckAndHandleBreakPoints();
   void RunLoop();
@@ -293,7 +295,7 @@ public:
   u64 ReadFullTimeBaseValue() const;
   void WriteFullTimeBaseValue(u64 value);
 
-  void SendSeqUDPPacket(PowerPCManager& power_pc, Memory::MemoryManager& memory);
+  bool CheckSeqExecution(PowerPCManager& power_pc, Memory::MemoryManager& memory);
 
   PowerPCState& GetPPCState() { return m_ppc_state; }
   const PowerPCState& GetPPCState() const { return m_ppc_state; }

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "Common/CommonTypes.h"
+#include "Common/WorkQueueThread.h"
 
 #include "Core/CPUThreadConfigCallback.h"
 #include "Core/Debugger/BranchWatch.h"
@@ -330,6 +331,9 @@ private:
   CoreTiming::EventType* m_invalidate_cache_thread_safe = nullptr;
 
   Core::System& m_system;
+
+  Common::WorkQueueThread<std::function<void()>> m_udp_queue;
+  void InitUDPQueue();
 };
 
 void UpdatePerformanceMonitor(u32 cycles, u32 num_load_stores, u32 num_fp_inst,

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -15,11 +15,13 @@
 #include "Core/CPUThreadConfigCallback.h"
 #include "Core/Debugger/BranchWatch.h"
 #include "Core/Debugger/PPCDebugInterface.h"
+#include "Core/HW/Memmap.h"
 #include "Core/PowerPC/BreakPoints.h"
 #include "Core/PowerPC/ConditionRegister.h"
 #include "Core/PowerPC/Gekko.h"
 #include "Core/PowerPC/PPCCache.h"
 #include "Core/PowerPC/PPCSymbolDB.h"
+#include <Core/HW/Memmap.h>
 
 class CPUCoreBase;
 class PointerWrap;
@@ -290,6 +292,8 @@ public:
   u64 ReadFullTimeBaseValue() const;
   void WriteFullTimeBaseValue(u64 value);
 
+  void SendSeqUDPPacket(PowerPCManager& power_pc, Memory::MemoryManager& memory);
+
   PowerPCState& GetPPCState() { return m_ppc_state; }
   const PowerPCState& GetPPCState() const { return m_ppc_state; }
   BreakPoints& GetBreakPoints() { return m_breakpoints; }
@@ -333,7 +337,7 @@ void UpdatePerformanceMonitor(u32 cycles, u32 num_load_stores, u32 num_fp_inst,
 
 void CheckExceptionsFromJIT(PowerPCManager& power_pc);
 void CheckExternalExceptionsFromJIT(PowerPCManager& power_pc);
-void CheckAndHandleBreakPointsFromJIT(PowerPCManager& power_pc);
+void CheckAndHandleBreakPointsFromJIT(PowerPCManager& power_pc, Memory::MemoryManager& memory);
 
 // Easy register access macros.
 #define HID0(ppc_state) ((UReg_HID0&)(ppc_state).spr[SPR_HID0])

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -334,6 +334,7 @@ private:
 
   Core::System& m_system;
 
+  bool recent_seq_bp = false;
   Common::SeqQueueThread<std::vector<char>> m_udp_queue;
   void InitUDPQueue();
 };

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -332,7 +332,7 @@ private:
 
   Core::System& m_system;
 
-  Common::SeqQueueThread<std::string> m_udp_queue;
+  Common::SeqQueueThread<std::vector<char>> m_udp_queue;
   void InitUDPQueue();
 };
 

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -11,7 +11,7 @@
 #include <vector>
 
 #include "Common/CommonTypes.h"
-#include "Common/WorkQueueThread.h"
+#include "Common/SeqQueueThread.h"
 
 #include "Core/CPUThreadConfigCallback.h"
 #include "Core/Debugger/BranchWatch.h"
@@ -332,7 +332,7 @@ private:
 
   Core::System& m_system;
 
-  Common::WorkQueueThread<std::function<void()>> m_udp_queue;
+  Common::SeqQueueThread<std::string> m_udp_queue;
   void InitUDPQueue();
 };
 

--- a/Source/Core/Core/PowerPC/PowerPC.h
+++ b/Source/Core/Core/PowerPC/PowerPC.h
@@ -296,6 +296,7 @@ public:
   void WriteFullTimeBaseValue(u64 value);
 
   bool CheckSeqExecution(PowerPCManager& power_pc, Memory::MemoryManager& memory);
+  bool IsSeqBreakpoint(u32 address);
 
   PowerPCState& GetPPCState() { return m_ppc_state; }
   const PowerPCState& GetPPCState() const { return m_ppc_state; }

--- a/Source/Core/DolphinQt/Debugger/BreakpointDialog.cpp
+++ b/Source/Core/DolphinQt/Debugger/BreakpointDialog.cpp
@@ -112,6 +112,27 @@ void BreakpointDialog::CreateWidgets()
   instruction_layout->addWidget(m_instruction_box, 1, 0, 1, 2);
   instruction_widget->setLayout(instruction_layout);
 
+  // SEQ BP
+  auto* seq_widget = new QWidget;
+  auto* seq_layout = new QGridLayout;
+
+  m_seq_bp = new QRadioButton(tr("SEQ Breakpoint"));
+  type_group->addButton(m_seq_bp);
+  m_seq_box = new QGroupBox;
+  m_seq_file = new QLineEdit;
+  m_seq_offset = new QLineEdit;
+
+  auto* seq_data_layout = new QGridLayout;
+  m_seq_box->setLayout(seq_data_layout);
+  seq_data_layout->addWidget(new QLabel(tr("File:")), 1, 0, 1, 1);
+  seq_data_layout->addWidget(m_seq_file, 1, 1, 1, 1);
+  seq_data_layout->addWidget(new QLabel(tr("Offset:")), 0, 0, 1, 1);
+  seq_data_layout->addWidget(m_seq_offset, 0, 1, 1, 1);
+
+  seq_layout->addWidget(m_seq_bp, 0, 0, 1, 1);
+  seq_layout->addWidget(m_seq_box, 1, 0, 1, 2);
+  seq_widget->setLayout(seq_layout);
+
   // Memory BP
   auto* memory_widget = new QWidget;
   auto* memory_layout = new QGridLayout;
@@ -191,6 +212,7 @@ void BreakpointDialog::CreateWidgets()
 
   auto* layout = new QVBoxLayout;
   layout->addWidget(instruction_widget);
+  layout->addWidget(seq_widget);
   layout->addWidget(memory_widget);
   layout->addWidget(action_box);
   layout->addWidget(m_buttons);
@@ -236,6 +258,7 @@ void BreakpointDialog::ConnectWidgets()
 void BreakpointDialog::OnBPTypeChanged()
 {
   m_instruction_box->setEnabled(m_instruction_bp->isChecked());
+  m_seq_box->setEnabled(m_seq_bp->isChecked());
   m_memory_box->setEnabled(m_memory_bp->isChecked());
 }
 
@@ -257,6 +280,7 @@ void BreakpointDialog::accept()
   };
 
   bool instruction = m_instruction_bp->isChecked();
+  bool seq = m_seq_bp->isChecked();
   bool ranged = m_memory_use_range->isChecked();
 
   // Triggers
@@ -290,6 +314,19 @@ void BreakpointDialog::accept()
     }
 
     m_parent->AddBP(address, do_break, do_log, condition);
+  }
+  else if (seq)
+  {
+    u32 offset = m_seq_offset->text().toUInt(&good, 16);
+    QString file = m_seq_file->text();
+
+    if (!good)
+    {
+      invalid_input(tr("Offset"));
+      return;
+    }
+
+    m_parent->AddSeqBP(offset, file.toStdString(), condition);
   }
   else
   {

--- a/Source/Core/DolphinQt/Debugger/BreakpointDialog.h
+++ b/Source/Core/DolphinQt/Debugger/BreakpointDialog.h
@@ -26,6 +26,7 @@ public:
   {
     New,
     EditBreakPoint,
+    EditSeqBreakPoint,
     EditMemCheck
   };
 
@@ -47,6 +48,12 @@ private:
   QRadioButton* m_instruction_bp;
   QGroupBox* m_instruction_box;
   QLineEdit* m_instruction_address;
+
+  // SEQ BPs
+  QRadioButton* m_seq_bp;
+  QGroupBox* m_seq_box;
+  QLineEdit* m_seq_file;
+  QLineEdit* m_seq_offset;
 
   // Memory BPs
   QRadioButton* m_memory_bp;

--- a/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
@@ -49,11 +49,11 @@ enum TableColumns
   SYMBOL_COLUMN = 2,
   ADDRESS_COLUMN = 3,
   END_ADDRESS_COLUMN = 4,
-  BREAK_COLUMN = 5,
-  LOG_COLUMN = 6,
-  READ_COLUMN = 7,
-  WRITE_COLUMN = 8,
-  FILE_COLUMN = 9,
+  FILE_COLUMN = 5,
+  BREAK_COLUMN = 6,
+  LOG_COLUMN = 7,
+  READ_COLUMN = 8,
+  WRITE_COLUMN = 9,
   CONDITION_COLUMN = 10,
 };
 }  // namespace
@@ -272,8 +272,8 @@ void BreakpointWidget::Update()
 
   m_table->clear();
   m_table->setHorizontalHeaderLabels({tr("Active"), tr("Type"), tr("Function"), tr("Address"),
-                                      tr("End Addr"), tr("Break"), tr("Log"), tr("Read"),
-                                      tr("Write"), tr("File"), tr("Condition")});
+                                      tr("End Addr"), tr("File"), tr("Break"), tr("Log"), tr("Read"),
+                                      tr("Write"), tr("Condition")});
   m_table->horizontalHeader()->setStretchLastSection(true);
 
   // Get row height for icons
@@ -341,9 +341,9 @@ void BreakpointWidget::Update()
     m_table->setItem(i, LOG_COLUMN, bp.log_on_hit ? icon_item.clone() : empty_item.clone());
 
     m_table->setItem(i, END_ADDRESS_COLUMN, disabled_item.clone());
+    m_table->setItem(i, FILE_COLUMN, create_item(QString::fromStdString(bp.file)));
     m_table->setItem(i, READ_COLUMN, disabled_item.clone());
     m_table->setItem(i, WRITE_COLUMN, disabled_item.clone());
-    m_table->setItem(i, FILE_COLUMN, create_item(QString::fromStdString(bp.file)));
 
     m_table->setItem(
         i, CONDITION_COLUMN,

--- a/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
@@ -616,6 +616,15 @@ void BreakpointWidget::AddBP(u32 addr, bool break_on_hit, bool log_on_hit, const
   emit Host::GetInstance()->PPCBreakpointsChanged();
 }
 
+void BreakpointWidget::AddSeqBP(u32 addr, const std::string file, const QString& condition)
+{
+  m_system.GetPowerPC().GetBreakPoints().Add(
+      addr, file,
+      !condition.isEmpty() ? Expression::TryParse(condition.toUtf8().constData()) : std::nullopt);
+
+  emit Host::GetInstance()->PPCBreakpointsChanged();
+}
+
 void BreakpointWidget::EditBreakpoint(u32 address, int edit, std::optional<QString> string)
 {
   TBreakPoint bp;

--- a/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
@@ -53,7 +53,8 @@ enum TableColumns
   LOG_COLUMN = 6,
   READ_COLUMN = 7,
   WRITE_COLUMN = 8,
-  CONDITION_COLUMN = 9,
+  FILE_COLUMN = 9,
+  CONDITION_COLUMN = 10,
 };
 }  // namespace
 
@@ -155,7 +156,7 @@ void BreakpointWidget::CreateWidgets()
   m_table->setItemDelegate(new CustomDelegate(this));
   m_table->setTabKeyNavigation(false);
   m_table->setContentsMargins(0, 0, 0, 0);
-  m_table->setColumnCount(10);
+  m_table->setColumnCount(11);
   m_table->setSelectionMode(QAbstractItemView::NoSelection);
   m_table->verticalHeader()->hide();
 
@@ -272,7 +273,7 @@ void BreakpointWidget::Update()
   m_table->clear();
   m_table->setHorizontalHeaderLabels({tr("Active"), tr("Type"), tr("Function"), tr("Address"),
                                       tr("End Addr"), tr("Break"), tr("Log"), tr("Read"),
-                                      tr("Write"), tr("Condition")});
+                                      tr("Write"), tr("File"), tr("Condition")});
   m_table->horizontalHeader()->setStretchLastSection(true);
 
   // Get row height for icons
@@ -342,6 +343,7 @@ void BreakpointWidget::Update()
     m_table->setItem(i, END_ADDRESS_COLUMN, disabled_item.clone());
     m_table->setItem(i, READ_COLUMN, disabled_item.clone());
     m_table->setItem(i, WRITE_COLUMN, disabled_item.clone());
+    m_table->setItem(i, FILE_COLUMN, create_item(QString::fromStdString(bp.file)));
 
     m_table->setItem(
         i, CONDITION_COLUMN,
@@ -400,6 +402,7 @@ void BreakpointWidget::Update()
     m_table->setItem(i, READ_COLUMN, mbp.is_break_on_read ? icon_item.clone() : empty_item.clone());
     m_table->setItem(i, WRITE_COLUMN,
                      mbp.is_break_on_write ? icon_item.clone() : empty_item.clone());
+    m_table->setItem(i, FILE_COLUMN, create_item(QString()));
 
     m_table->setItem(
         i, CONDITION_COLUMN,
@@ -422,6 +425,7 @@ void BreakpointWidget::Update()
   m_table->resizeColumnToContents(LOG_COLUMN);
   m_table->resizeColumnToContents(READ_COLUMN);
   m_table->resizeColumnToContents(WRITE_COLUMN);
+  m_table->resizeColumnToContents(FILE_COLUMN);
 }
 
 void BreakpointWidget::OnClear()

--- a/Source/Core/DolphinQt/Debugger/BreakpointWidget.h
+++ b/Source/Core/DolphinQt/Debugger/BreakpointWidget.h
@@ -35,6 +35,7 @@ public:
 
   void AddBP(u32 addr);
   void AddBP(u32 addr, bool break_on_hit, bool log_on_hit, const QString& condition);
+  void AddSeqBP(u32 addr, const std::string file, const QString& condition);
   void AddAddressMBP(u32 addr, bool on_read = true, bool on_write = true, bool do_log = true,
                      bool do_break = true, const QString& condition = {});
   void AddRangedMBP(u32 from, u32 to, bool do_read = true, bool do_write = true, bool do_log = true,


### PR DESCRIPTION
This PR introduces two features into the current master branch of [Dolphin](https://github.com/dolphin-emu/dolphin):

1. Allows you to send the current state of the SEQ interpreter during GNT4/SCON4/QOLE game execution to GNTool. This is read by GNTool via https://github.com/NicholasMoser/GNTool/pull/85 and is displayed in such a way that you can see which file and which line of SEQ code is being executed. You may also click that line to disassemble that specific opcode.

![image](https://github.com/user-attachments/assets/2f883bc9-c8d4-4c84-86e6-a7358186feaa)

Because many SEQ opcodes are run per frame, each execution is batched into a single UDP packet, up to 1000. These are then sent all at once asynchronously to GNTool which will create the events from the single packet via https://github.com/NicholasMoser/GNTool/pull/164. This enhancement has allowed it to match the performance of the existing implementation via a [Lua Dolphin fork](https://github.com/NicholasMoser/dolphin/releases/tag/lua-dolphin-1.0) and [https://github.com/NicholasMoser/Naruto-GNT-Modding/blob/main/utils/udp_gnt4.lua](https://github.com/NicholasMoser/Naruto-GNT-Modding/blob/main/utils/udp_gnt4.lua).

2. Allows you to set breakpoints on specific lines of specific SEQ files.

![image](https://github.com/user-attachments/assets/ed4d1491-8a04-41fb-b8e7-cef5f8454628)

As shown above, you put in enough of the end of the filepath to match the file, so for cases where the filename conflicts you would include the directory, e.g. `ank/0000.seq`

![image](https://github.com/user-attachments/assets/ca68c11a-a588-4864-8f00-0f69b3609ad7)

![image](https://github.com/user-attachments/assets/3c4268dd-d8ac-4d32-9df7-e884d12f9025)
